### PR TITLE
Lindsay tasks

### DIFF
--- a/remake.yml
+++ b/remake.yml
@@ -12,8 +12,7 @@ sources:
 targets:
   all:
     depends:
-      - sb_xml
-      - sb_data
+      - sb_posted
     
 
       
@@ -34,21 +33,19 @@ targets:
     command: file.copy(from = "example_data/example_cars.csv", 
       to = target_name)
   
-
   out_data/spatial.zip:
     command: sf_to_zip(zip_filename = target_name, 
       sf_object = sf_spatial_data, layer_name = I('spatial_data'))
 
-  
-  sb_data:
+  out_xml/fgdc_metadata.xml:
+    command: render(filename = target_name,
+      "in_text/text_data_release.yml",
+      spatial_metadata)
+    
+  sb_posted:
     command: sb_replace_files(sbid,
       "out_data/spatial.zip",
       "out_data/cars.csv",
+      "out_xml/fgdc_metadata.xml",
       sources = "src/sb_utils.R")
       
-  sb_xml:
-    command: sb_render_post_xml(sbid,
-      "in_text/text_data_release.yml",
-      spatial_metadata, 
-      xml_file = I("out_xml/fgdc_metadata.xml"),
-      sources = "src/sb_utils.R")

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -89,7 +89,7 @@ do_item_replace_tasks <- function(sb_id, files, sources) {
     packages = c('sbtools', 'scipiper', 'dplyr'),
     sources = sources,
     final_targets = final_target,
-    finalize_funs = "combine_upload_times",
+    finalize_funs = "bind_rows",
     as_promises = FALSE)
   
   # Build the tasks
@@ -120,8 +120,4 @@ upload_and_record <- function(sb_id, file) {
   
   # Then record when it happened and return that as an obj
   return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
-}
-
-combine_upload_times <- function(...) {
-  bind_rows(list(...))
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -11,34 +11,17 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   
   files <- c(...)
   
-  # Throw error if there are no files given to push
-  stopifnot(length(files) > 0 | !missing(file_hash))
-  
-  # Keep login check here as well as in `upload_and_record` in case the task table
-  # method is not used
-  if (!sbtools::is_logged_in()){
-    sb_secret <- dssecrets::get_dssecret("cidamanager-sb-srvc-acct")
-    sbtools::authenticate_sb(username = sb_secret$username, password = sb_secret$password)
-  }
-  
-  hashed_filenames <- c()
   if (!missing(file_hash)){
-    hashed_filenames <- yaml.load_file(file_hash) %>% names %>% sort() %>% rev()
-    if(use_task_table) {
-      do_item_replace_tasks(sb_id, hashed_filenames, sources)
-    } else {
-      for (file in hashed_filenames){
-        item_replace_files(sb_id, files = file)
-      }
-    }
+    files <- c(files, names(yaml.load_file(file_hash))) %>% sort() 
   }
-  
-  if (length(files) > 0){
-    if(use_task_table) {
-      do_item_replace_tasks(sb_id, files, sources)
-    } else {
-      item_replace_files(sb_id, files = files)
-    }
+
+  # Throw error if there are no files given to push
+  stopifnot(length(files) > 0)
+
+  if(use_task_table) {
+    do_item_replace_tasks(sb_id, files, sources)
+  } else {
+    upload_and_record(sb_id, file = files)
   }
   
 }

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -30,13 +30,14 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
 do_item_replace_tasks <- function(sb_id, files, sources) {
   
   # Define task table rows
-  task_df <- tibble(filepath = files) %>% mutate(task_name = paste0('uploaded_file_', row_number()))
+  task_df <- tibble(filepath = files) %>% 
+    mutate(task_name = sprintf('sb_%s_%s_file', sb_id, basename(filepath)))
   
   # Define task table columns
   sb_push <- scipiper::create_task_step(
     step_name = 'push_file_to_sb',
     target_name = function(task_name, step_name, ...){
-      sprintf("%s_pushed_to_sb", task_name)
+      task_name
     },
     command = function(task_name, ...){
       sprintf("upload_and_record(I('%s'), '%s')", sb_id, 
@@ -53,7 +54,8 @@ do_item_replace_tasks <- function(sb_id, files, sources) {
   
   # Create the task remakefile
   task_yml <- "file_upload_tasks.yml"
-  final_target <- "upload_timestamps"
+  final_target <- sprintf("upload_%s_timestamps", sb_id)
+  
   create_task_makefile(
     task_plan = task_plan,
     makefile = task_yml,

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -43,18 +43,6 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   
 }
 
-sb_render_post_xml <- function(sb_id, ..., xml_file = NULL, use_task_table = TRUE, sources = c()){
-  
-  if (is.null(xml_file)){
-    xml_file <- file.path(tempdir(), paste0(sb_id,'.xml'))
-  }
-  
-  render(filename = xml_file, ...)
-  
-  sb_replace_files(sb_id = sb_id, xml_file, use_task_table, sources)
-  
-}
-
 # Helper function to create a task_table for the files that need to be pushed to SB
 do_item_replace_tasks <- function(sb_id, files, sources) {
   


### PR DESCRIPTION
I had some suggestions for you PR. 

Most of these are straightforward, but the reason I modified the body of `sb_replace_files` is because it didn't seem like there was a need to separate `files` from the file names in the hash table. I also changed the call from `item_replace_files` to `upload_and_record` when you specify `use_task_table = FALSE` because `item_replace_files` and the task table call return two different things, so you'd get a different function return from `sb_replace_files` depending on whether you used task tables, which I don't think should be the case. 