### PR TITLE
A couple of additional suggestions

### DIFF
--- a/remake.yml
+++ b/remake.yml
@@ -15,10 +15,6 @@ targets:
       - sb_posted
     
 
-      
-  sbid:
-    command: c(I('5faaac68d34eb413d5df1f22'))
-
   sf_spatial_data:
     command: st_read('example_data/example_shapefile/example_shapefile.shp')
     depends:
@@ -42,8 +38,9 @@ targets:
       "in_text/text_data_release.yml",
       spatial_metadata)
     
-  sb_posted:
-    command: sb_replace_files(sbid,
+  log/sb_posted_files.csv:
+    command: sb_replace_files(filename = target_name, 
+      sbid = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
       "out_xml/fgdc_metadata.xml",

--- a/remake.yml
+++ b/remake.yml
@@ -1,6 +1,8 @@
 packages:
   - tidyverse
   - meddle # at least v0.0.12
+  - scipiper
+  - readr
   - dssecrets
   - sbtools
   - sf
@@ -12,7 +14,7 @@ sources:
 targets:
   all:
     depends:
-      - sb_posted
+      - log/sb_posted_files.csv
     
 
   sf_spatial_data:
@@ -40,7 +42,7 @@ targets:
     
   log/sb_posted_files.csv:
     command: sb_replace_files(filename = target_name, 
-      sbid = I('5faaac68d34eb413d5df1f22'),
+      sb_id = I('5faaac68d34eb413d5df1f22'),
       "out_data/spatial.zip",
       "out_data/cars.csv",
       "out_xml/fgdc_metadata.xml",

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -7,7 +7,7 @@
 #' `do_item_replace_tasks`, `upload_and_record`, and `combine_upload_times` are defined. It 
 #' might be easier to put them all in the same file.
 #' 
-sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sources = c()){
+sb_replace_files <- function(filename, sb_id, ..., file_hash, use_task_table = TRUE, sources = c()){
   
   files <- c(...)
   
@@ -19,11 +19,11 @@ sb_replace_files <- function(sb_id, ..., file_hash, use_task_table = TRUE, sourc
   stopifnot(length(files) > 0)
 
   if(use_task_table) {
-    do_item_replace_tasks(sb_id, files, sources)
+    out_log <- do_item_replace_tasks(sb_id, files, sources)
   } else {
-    upload_and_record(sb_id, file = files)
+    out_log <- upload_and_record(sb_id, file = files)
   }
-  
+  write_csv(out_log, filename)
 }
 
 # Helper function to create a task_table for the files that need to be pushed to SB

--- a/src/sb_utils.R
+++ b/src/sb_utils.R
@@ -92,5 +92,5 @@ upload_and_record <- function(sb_id, file) {
   timestamp_chr <- format(timestamp, "%Y-%m-%d %H:%M %Z")
   
   # Then record when it happened and return that as an obj
-  return(tibble(file = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
+  return(tibble(filepath = file, sb_id = sb_id, time_uploaded_to_sb = timestamp_chr))
 }


### PR DESCRIPTION
I thought the timestamp target would be better as a file so we could put it in github and it would then clearly show when updates were made and the github file would render nicely w/o having to build the object target and look at it locally, so some changes for that. 

Also, I just put the `sb_id` in as an argument, since using it as a target wasn't needed since there is only one push target now. 